### PR TITLE
fix debug-settings missing test-identifiers

### DIFF
--- a/lib/src/widgets/admob_consent_manager.dart
+++ b/lib/src/widgets/admob_consent_manager.dart
@@ -30,7 +30,10 @@ class ConsentManager {
     ConsentDebugSettings? debugSettings;
 
     if (AdHelper.showConstentGDPR && kDebugMode) {
-      debugSettings = ConsentDebugSettings(debugGeography: DebugGeography.debugGeographyEea);
+      debugSettings = ConsentDebugSettings(
+        debugGeography: DebugGeography.debugGeographyEea,
+        testIdentifiers: AdHelper.testDeviceIds,
+      );
     }
     ConsentRequestParameters params = ConsentRequestParameters(consentDebugSettings: debugSettings);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: easy_admob_ads_flutter
 description: A simple and flexible Flutter package to integrate AdMob ad formats with minimal setup.
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/huzaibsayyed/easy_admob_ads_flutter
 repository: https://github.com/huzaibsayyed/easy_admob_ads_flutter
 issue_tracker: https://github.com/huzaibsayyed/easy_admob_ads_flutter/issues


### PR DESCRIPTION
need to provide `testIdentifiers` in `ConsentDebugSettings`

on the emulator running (consent form appears) without `testIdentifiers`

**Android emulators are automatically configured as test devices.**
**iOS simulators are automatically configured as test devices.**
https://developers.google.com/admob/android/test-ads